### PR TITLE
Add support for namespaces

### DIFF
--- a/src/craco.config.js
+++ b/src/craco.config.js
@@ -13,7 +13,7 @@ const isDevserverWebsocketRequest = (request) =>
   (request.headers.upgrade === 'websocket' || request.headers['sec-websocket-version']);
 
 function mayProxy(pathname) {
-  const publicPrefixPrefix = '/static-files/';
+  const publicPrefixPrefix = '/static/mlflow/';
   if (pathname.startsWith(publicPrefixPrefix)) {
     const maybePublicPath = path.resolve('public', pathname.substring(publicPrefixPrefix.length));
     return !fs.existsSync(maybePublicPath);
@@ -74,7 +74,7 @@ function configureIframeCSSPublicPaths(config, env) {
           cssRule.use
             ?.filter((loaderConfig) => loaderConfig?.loader.match(/\/mini-css-extract-plugin\//))
             .forEach((loaderConfig) => {
-              let publicPath = '/mlflow/static-files/';
+              let publicPath = '/static/mlflow/';
               // eslint-disable-next-line no-param-reassign
               loaderConfig.options = { publicPath };
 
@@ -276,7 +276,7 @@ module.exports = function ({ env }) {
     },
     webpack: {
       configure: (webpackConfig, { env, paths }) => {
-        webpackConfig.output.publicPath = 'static-files/';
+        webpackConfig.output.publicPath = '/static/mlflow/';
         webpackConfig = i18nOverrides(webpackConfig);
         webpackConfig = configureIframeCSSPublicPaths(webpackConfig, env);
         webpackConfig = enableOptionalTypescript(webpackConfig);

--- a/src/package.json
+++ b/src/package.json
@@ -172,7 +172,7 @@
     "prep-deps": ": # magic task to allow yarn ensure-deps plugin prepare dependencies of this package"
   },
   "//": "homepage is hard to configure without resorting to env variables and doesn't play nicely with other webpack settings. This field should be removed.",
-  "homepage": "static-files",
+  "homepage": "/static/mlflow/",
   "browserslist": [
     "defaults"
   ],

--- a/src/public/index.html
+++ b/src/public/index.html
@@ -3,14 +3,18 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <link rel="shortcut icon" href="./static-files/favicon.ico" />
+    <link rel="shortcut icon" href="/static/mlflow/favicon.ico" />
     <meta name="theme-color" content="#000000" />
     <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
-    <link rel="manifest" href="./static-files/manifest.json" />
+    <link rel="manifest" href="/static/mlflow/manifest.json" />
     <title>FastTrackML (classic)</title>
+    <script>
+      const found = window.location.pathname.match(/^(\/ns\/[^/]+\/)mlflow/);
+      window.API_BASE_PATH = found ? found[1] : '/';
+    </script>
   </head>
 
   <body>

--- a/src/src/common/utils/FetchUtils.ts
+++ b/src/src/common/utils/FetchUtils.ts
@@ -4,6 +4,19 @@ import yaml from 'js-yaml';
 import _ from 'lodash';
 import { ErrorWrapper } from './ErrorWrapper';
 
+interface GlobalScope extends Window {
+  API_BASE_PATH?: string;
+}
+
+let globalScope: GlobalScope;
+
+try {
+  globalScope = window;
+} catch (ex) {
+  /* eslint-disable-next-line no-restricted-globals */
+  globalScope = self;
+}
+
 export const HTTPMethods = {
   GET: 'GET',
   POST: 'POST',
@@ -49,7 +62,7 @@ export const getAjaxUrl = (relativeUrl: any) => {
   if (process.env.USE_ABSOLUTE_AJAX_URLS === 'true' && !relativeUrl.startsWith('/')) {
     return '/' + relativeUrl;
   }
-  return relativeUrl;
+  return globalScope.API_BASE_PATH + relativeUrl;
 };
 
 // return response json by default, if response is not parsable to json,

--- a/src/src/experiment-tracking/components/App.tsx
+++ b/src/src/experiment-tracking/components/App.tsx
@@ -97,7 +97,7 @@ class App extends Component {
                   </NavLink>
                 </div>
                 <div className='header-links'>
-                  <a href={'/'} css={{ marginRight }}>
+                  <a href={'../'} css={{ marginRight }}>
                     <div className='github'>
                       <span>Switch UI</span>
                     </div>

--- a/src/src/experiment-tracking/components/artifact-view-components/ShowArtifactPdfView.tsx
+++ b/src/src/experiment-tracking/components/artifact-view-components/ShowArtifactPdfView.tsx
@@ -10,7 +10,7 @@ import { ErrorWrapper } from '../../../common/utils/ErrorWrapper';
 
 // See: https://github.com/wojtekmaj/react-pdf/blob/master/README.md#enable-pdfjs-worker for how
 // workerSrc is supposed to be specified.
-pdfjs.GlobalWorkerOptions.workerSrc = `./static-files/pdf.worker.js`;
+pdfjs.GlobalWorkerOptions.workerSrc = `/static/mlflow/pdf.worker.js`;
 
 type OwnProps = {
   runUuid: string;


### PR DESCRIPTION
In order to support the major changes in https://github.com/G-Research/fasttrackml/pull/259, the MLFlow UI needs to be adapted to know how to call the correct namespaced API, and to get its static files from a central location.