### PR TITLE
Change `get-artifact` endpoint to `ajax-api/2.0/mlflow/artifacts/get`

### DIFF
--- a/src/craco.config.js
+++ b/src/craco.config.js
@@ -284,9 +284,6 @@ module.exports = function ({ env }) {
         return webpackConfig;
       },
       plugins: [
-        new webpack.DefinePlugin({
-          'process.env.HOSTED_PATH': JSON.stringify(''),
-        }),
         new webpack.EnvironmentPlugin({
           HIDE_HEADER: process.env.HIDE_HEADER ? 'true' : 'false',
           HIDE_EXPERIMENT_LIST: process.env.HIDE_EXPERIMENT_LIST ? 'true' : 'false',

--- a/src/src/common/utils/FetchUtils.ts
+++ b/src/src/common/utils/FetchUtils.ts
@@ -17,6 +17,10 @@ try {
   globalScope = self;
 }
 
+export const getBasePath = () => {
+  return `${globalScope.API_BASE_PATH}`;
+};
+
 export const HTTPMethods = {
   GET: 'GET',
   POST: 'POST',
@@ -62,7 +66,7 @@ export const getAjaxUrl = (relativeUrl: any) => {
   if (process.env.USE_ABSOLUTE_AJAX_URLS === 'true' && !relativeUrl.startsWith('/')) {
     return '/' + relativeUrl;
   }
-  return globalScope.API_BASE_PATH + relativeUrl;
+  return getBasePath() + relativeUrl;
 };
 
 // return response json by default, if response is not parsable to json,

--- a/src/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.tsx
+++ b/src/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { getBasePath } from '../../../common/utils/FetchUtils';
 import {
   getExtension,
   IMAGE_EXTENSIONS,
@@ -147,12 +148,10 @@ const getFileTooLargeView = () => {
 };
 
 export const getSrc = (path: any, runUuid: any) => {
-  // @ts-expect-error TS(4111): Property 'HOSTED_PATH' comes from an index signatu... Remove this comment to see the full error message
-  const basePath = process.env.HOSTED_PATH || '';
-  const endpointPath = 'get-artifact';
-  return `${basePath}${endpointPath}?path=${encodeURIComponent(path)}&run_uuid=${encodeURIComponent(
-    runUuid,
-  )}`;
+  const endpointPath = 'ajax-api/2.0/mlflow/artifacts/get';
+  return `${getBasePath()}${endpointPath}?path=${encodeURIComponent(
+    path,
+  )}&run_uuid=${encodeURIComponent(runUuid)}`;
 };
 
 export default ShowArtifactPage;


### PR DESCRIPTION
This PR changes the way the endpoint to get an artifact from the UI is computed from `get-artifact` relative to where the UI has been served to `ajax-api/2.0/mlflow/artifacts/get` under the selected namespace, bringing this endpoint back into the fold of all the other API calls.

Fixes https://github.com/G-Research/fasttrackml/issues/356.