### PR TITLE
Namespace Selector in MlFlow UI

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -41,7 +41,6 @@
     "@databricks/design-system": "file:./vendor/design-system",
     "@emotion/cache": "^11.4.0",
     "@emotion/react": "^11.4.0",
-    "@material-ui/core": "^4.12.4",
     "@tanstack/react-table": "^8.8.2",
     "@types/react-virtualized": "^9.21.9",
     "antd": "4.16.8",

--- a/src/package.json
+++ b/src/package.json
@@ -41,6 +41,7 @@
     "@databricks/design-system": "file:./vendor/design-system",
     "@emotion/cache": "^11.4.0",
     "@emotion/react": "^11.4.0",
+    "@material-ui/core": "^4.12.4",
     "@tanstack/react-table": "^8.8.2",
     "@types/react-virtualized": "^9.21.9",
     "antd": "4.16.8",

--- a/src/src/experiment-tracking/components/App.css
+++ b/src/src/experiment-tracking/components/App.css
@@ -183,3 +183,7 @@ pre {
   border: 1px solid #ccc;
   border-radius: 4px;
 }
+
+.namespace-select .ant-select-arrow {
+  color: #e7f1fb;
+}

--- a/src/src/experiment-tracking/components/App.tsx
+++ b/src/src/experiment-tracking/components/App.tsx
@@ -146,7 +146,10 @@ class App extends Component {
                   size='small'
                   value={this.state.selectedNamespace} 
                   onChange={this.handleNamespaceChange}
-                  style={{ marginRight, width: 130 }}
+                  style={{ marginRight: 15, color: '#e7f1fb', fontSize: 16 }}
+                  bordered={false}
+                  dropdownMatchSelectWidth={false}
+                  className="namespace-select"
                 >
                   {this.state.namespaces.map((namespace) => (
                     <Select.Option value={namespace}>

--- a/src/src/experiment-tracking/components/App.tsx
+++ b/src/src/experiment-tracking/components/App.tsx
@@ -64,8 +64,8 @@ class App extends Component {
   constructor(props: any) {
     super(props);
     this.state = {
-      selectedNamespace: 'ns1',
-      namespaces: ['cccccc787493', 'ddd', 'ns1', 'ns2'],
+      selectedNamespace: '',
+      namespaces: [],
       version: 'unknown',
     };
     this.handleNamespaceChange = this.handleNamespaceChange.bind(this);

--- a/src/src/experiment-tracking/components/App.tsx
+++ b/src/src/experiment-tracking/components/App.tsx
@@ -7,8 +7,7 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import Select from '@material-ui/core/Select';
-import MenuItem from '@material-ui/core/MenuItem';
+import { Select } from 'antd';
 
 import {
   HashRouterV5,
@@ -65,15 +64,14 @@ class App extends Component {
   constructor(props: any) {
     super(props);
     this.state = {
-      selectedNamespace: '',
-      namespaces: [],
+      selectedNamespace: 'ns1',
+      namespaces: ['cccccc787493', 'ddd', 'ns1', 'ns2'],
       version: 'unknown',
     };
     this.handleNamespaceChange = this.handleNamespaceChange.bind(this);
   }
 
-  handleNamespaceChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    const value = event.target.value as string;
+  handleNamespaceChange = (value: string) => {
     this.setState({ 
       selectedNamespace: value,
     }, () => {
@@ -145,15 +143,15 @@ class App extends Component {
                 </div>
                 <div className='header-links'>
                 <Select 
-                  id="namespace-select"
+                  size='small'
                   value={this.state.selectedNamespace} 
                   onChange={this.handleNamespaceChange}
-                  style={{ marginRight, color: '#e7f1fb' }}
+                  style={{ marginRight, width: 130 }}
                 >
                   {this.state.namespaces.map((namespace) => (
-                    <MenuItem value={namespace} key={namespace}>
+                    <Select.Option value={namespace}>
                       {namespace}
-                    </MenuItem>
+                    </Select.Option>
                   ))}
                 </Select>
                   <a href={'../'} css={{ marginRight }}>


### PR DESCRIPTION
Fixes https://github.com/G-Research/fasttrackml/issues/463.
Introduces namespace selector in the mlflow UI.
<img width="421" alt="Screenshot 2024-01-20 at 20 16 54" src="https://github.com/G-Research/fasttrackml-ui-mlflow/assets/93596376/2d723579-84f9-4cd1-9c59-b0cf9acc7cc0">
<img width="421" alt="Screenshot 2024-01-20 at 20 17 01" src="https://github.com/G-Research/fasttrackml-ui-mlflow/assets/93596376/6ea6d88d-225e-4423-ac54-d3bcc1e433cb">



